### PR TITLE
Fix XML parsing for CBZ with one page

### DIFF
--- a/cbz/comic.py
+++ b/cbz/comic.py
@@ -146,7 +146,7 @@ class ComicInfo(ComicModel):
 
             if XML_NAME in names:
                 with zf.open(XML_NAME, 'r') as f:
-                    comic_info = xmltodict.parse(f.read()).get('ComicInfo', {})
+                    comic_info = xmltodict.parse(f.read(), force_list=('Pages',)).get('ComicInfo', {})
                 names.remove(XML_NAME)
 
             comic = __info(


### PR DESCRIPTION
This pull request addresses the issue described in #10. The following changes have been made:

-    Added force_list parameter in xmltodict parsing to get a list of pages regardless of the number of pages in the CBZ.