### PR TITLE
Fix pathlib import in "utils.py"

### DIFF
--- a/cbz/utils.py
+++ b/cbz/utils.py
@@ -3,7 +3,7 @@ from io import BytesIO
 
 from PIL import Image
 from PIL.IcoImagePlugin import IcoFile
-from path import Path
+from pathlib import Path
 
 
 def default_attr(value: any) -> any:


### PR DESCRIPTION
I had a problem with the import in a new environment.

I don't see any particular reason to use the **Path** of the path module instead of the standard Python module (available since version 3.5).