### PR TITLE
Replace PyMuPDF with pypdf for PDF handling

### DIFF
--- a/cbz/comic.py
+++ b/cbz/comic.py
@@ -8,7 +8,7 @@ from io import BytesIO
 from typing import Union
 from pathlib import Path
 
-import fitz
+from pypdf import PdfReader
 import xmltodict
 
 from cbz.constants import XML_NAME, COMIC_FIELDS, IMAGE_FORMAT, PAGE_FIELDS
@@ -98,13 +98,10 @@ class ComicInfo(ComicModel):
             ComicInfo: An instance of ComicInfo.
         """
         pages: list[PageInfo] = []
-        with fitz.open(path) as pf:
-            for element in pf:
-                # Check if the page has images
-                images = element.get_images(full=True)
-                for i, image in enumerate(images):
-                    base = pf.extract_image(image[0])
-                    pages.append(PageInfo.loads(data=base['image']))
+        reader = PdfReader(path)
+        for page in reader.pages:
+            for image in page.images:
+                pages.append(PageInfo.loads(data=image.data))
 
         assert pages, 'No valid images present in file'
         return ComicInfo.from_pages(pages=pages)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ python = ">=3.8"
 xmltodict = ">=0.13.0"
 langcodes = ">=3.4.0"
 Pillow = ">=10.4.0"
-PyMuPDF = ">=1.24.7"
+pypdf = ">=5.6.1"
 
 [tool.poetry.scripts]
 cbzplayer = "cbz.__main__:main"


### PR DESCRIPTION
This commit replaces the PyMuPDF (fitz) library with pypdf for handling PDF files.

The main reasons for this change are as follows:
- PyMuPDF is licensed under AGPL-3.0, which is incompatible with this project's license.
- pypdf is a pure-Python library, which simplifies the installation process and improves portability by removing the dependency on MuPDF native binaries.