### PR TITLE
Fix ComicInfo XML parsing for single page comic

### DIFF
--- a/cbz/comic.py
+++ b/cbz/comic.py
@@ -161,7 +161,7 @@ class ComicInfo(ComicModel):
 
         if XML_NAME in names:
             with archive_file.open(XML_NAME, 'r') as f:
-                comic_info = xmltodict.parse(f.read()).get('ComicInfo', {})
+                comic_info = xmltodict.parse(f.read(), force_list=('Page',)).get('ComicInfo', {})
             names.remove(XML_NAME)
 
         comic = ComicInfo.__extract_info(

--- a/tests/test_comic.py
+++ b/tests/test_comic.py
@@ -1,3 +1,4 @@
+import tempfile
 from pathlib import Path
 from typing import List
 
@@ -157,3 +158,22 @@ class TestComicInfo:
 
         assert comic.title == 'Empty Test'
         assert len(comic.pages) == 0
+
+    def test_single_page_comic_load(self, images_dir):
+        """Test loading comic with a single page."""
+        image_paths = sorted(list(images_dir.iterdir()))[:1]
+        pages = [PageInfo.load(path=path) for path in image_paths]
+
+        comic = ComicInfo.from_pages(pages=pages, title="Single Page Test")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir) / "single_page.cbz"
+            data = comic.pack()
+            with open(temp_path, "wb") as f:
+                f.write(data)
+
+            assert temp_path.exists()
+
+            comic_loaded = ComicInfo.from_cbz(temp_path)
+            assert comic_loaded.title == "Single Page Test"
+            assert len(comic_loaded.pages) == 1


### PR DESCRIPTION
When parsing `ComicInfo.xml` with `xmltodict`, single `Page` elements were being parsed as dictionaries instead of lists. This caused issues when processing single-page comics.