### PR TITLE
Add compression argument to pack and unpack methods

### DIFF
--- a/cbz/comic.py
+++ b/cbz/comic.py
@@ -176,7 +176,7 @@ class ComicInfo(ComicModel):
 
             # Some archives may contain folders or hidden files (e.g., ".extra/" or "__MACOSX/.DS_Store")
             # that could corrupt the suffix detection and cause invalid image handling.
-            if suffix not in IMAGE_FORMAT:
+            if suffix.lower() not in IMAGE_FORMAT:
                 logging.warning(f'Skipping unsupported or invalid file: {name!r} (suffix={suffix!r})')
                 continue
 

--- a/cbz/comic.py
+++ b/cbz/comic.py
@@ -207,7 +207,7 @@ class ComicInfo(ComicModel):
             return ComicInfo.__process_archive(rf)
 
     @staticmethod
-    def __unpack_zip(path: Path) -> ComicInfo:
+    def __unpack_zip(path: Path, compression: int = zipfile.ZIP_STORED) -> ComicInfo:
         """
         Unpack a CBZ file and create a ComicInfo instance.
 
@@ -217,7 +217,7 @@ class ComicInfo(ComicModel):
         Returns:
             ComicInfo: An instance of ComicInfo.
         """
-        with zipfile.ZipFile(path, 'r', zipfile.ZIP_STORED) as zf:
+        with zipfile.ZipFile(path, 'r', compression) as zf:
             return ComicInfo.__process_archive(zf)
 
     def get_info(self) -> dict:
@@ -271,7 +271,7 @@ class ComicInfo(ComicModel):
         })
         return comic_info
 
-    def pack(self, rename: bool = True) -> bytes:
+    def pack(self, rename: bool = True, compression: int = zipfile.ZIP_STORED) -> bytes:
         """
         Pack the comic information and pages into a CBZ file format.
 
@@ -282,7 +282,7 @@ class ComicInfo(ComicModel):
             bytes: Bytes representing the packed CBZ file.
         """
         zip_buffer = BytesIO()
-        with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_STORED) as zf:
+        with zipfile.ZipFile(zip_buffer, 'w', compression) as zf:
             content = xmltodict.unparse({'ComicInfo': self.get_info()}, pretty=True)
             zf.writestr(
                 XML_NAME,


### PR DESCRIPTION
Updated the __unpack_zip and pack methods to accept a compression argument for more flexibility in handling zip files.

Also adds a .lower() call to the suffix check, to allow extensions like "JPG" to continue, where they currently fail

### Why?

I am using this library in my project [Transmute](https://github.com/transmute-app/transmute), and I want to be able to create the CBZ archives with the DEFLATE compression setting for slightly smaller files. This PR is backwards compatible and requires no changes to current users, it only exposes this option as an arg for cases like mine.